### PR TITLE
Update to LibreOffice 4.4.5

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -6,12 +6,12 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 
 # config
-VERSION="4.1.4"
+VERSION="4.4.5"
 
 # LibreOffice Binaries URL
 FILE_NAME=libreoffice${VERSION}_x86-64.tar.gz
 BUILDPACK_LIBREOFFICE_PACKAGE=https://sourceforge.net/projects/herokubuildpacklibreoffice/files/${FILE_NAME}
-ARCHIVE_NAME=opt/libreoffice4.1
+ARCHIVE_NAME=opt/libreoffice${VERSION}
 
 # LibreOffice Dependencies URL
 DEPS_FILE_NAME=libreoffice_deps.tar.gz

--- a/bin/compile
+++ b/bin/compile
@@ -9,13 +9,13 @@ CACHE_DIR=$2
 VERSION="4.4.5"
 
 # LibreOffice Binaries URL
-FILE_NAME=libreoffice${VERSION}_x86-64.tar.gz
-BUILDPACK_LIBREOFFICE_PACKAGE=https://sourceforge.net/projects/herokubuildpacklibreoffice/files/${FILE_NAME}
+FILE_NAME=libreoffice${VERSION}_x86-64.tar
+BUILDPACK_LIBREOFFICE_PACKAGE=https://s3.amazonaws.com/buildpack-libreoffice/${FILE_NAME}
 ARCHIVE_NAME=opt/libreoffice${VERSION}
 
 # LibreOffice Dependencies URL
-DEPS_FILE_NAME=libreoffice_deps.tar.gz
-DEPS_BUILDPACK_LIBREOFFICE_PACKAGE=https://sourceforge.net/projects/herokubuildpacklibreoffice/files/${DEPS_FILE_NAME}
+DEPS_FILE_NAME=libreoffice_deps.tar
+DEPS_BUILDPACK_LIBREOFFICE_PACKAGE=https://s3.amazonaws.com/buildpack-libreoffice/${DEPS_FILE_NAME}
 DEPS_ARCHIVE_NAME=app/vendor/libreoffice/deps
 
 mkdir -p $CACHE_DIR

--- a/build/libreoffice.sh
+++ b/build/libreoffice.sh
@@ -4,7 +4,7 @@
 VERSION="4.1.4"
 
 # Official download for .debs
-DEB_DOWNLOAD_URL="http://download.documentfoundation.org/libreoffice/stable/4.1.4/deb/x86_64/LibreOffice_${VERSION}_Linux_x86-64_deb.tar.gz"
+DEB_DOWNLOAD_URL="http://download.documentfoundation.org/libreoffice/stable/${VERSION}/deb/x86_64/LibreOffice_${VERSION}_Linux_x86-64_deb.tar.gz"
 GETTEXT_DOWNLOAD_URL="http://ftp.gnu.org/pub/gnu/gettext/gettext-0.18.3.1.tar.gz"
 DBUS_DOWNLOAD_URL="http://dbus.freedesktop.org/releases/dbus/dbus-1.6.18.tar.gz"
 LIBFFI_DOWNLOAD_URL="ftp://sourceware.org/pub/libffi/libffi-3.0.13.tar.gz"

--- a/build/libreoffice.sh
+++ b/build/libreoffice.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # The current LibreOffice version
-VERSION="4.1.4"
+VERSION="4.4.5"
 
 # Official download for .debs
 DEB_DOWNLOAD_URL="http://download.documentfoundation.org/libreoffice/stable/${VERSION}/deb/x86_64/LibreOffice_${VERSION}_Linux_x86-64_deb.tar.gz"


### PR DESCRIPTION
I've updated the script to build the most recent 4.4.* version of LibreOffice. I've also moved away from source forge to my own s3 account until GitHub large file storage is available. The new binaries are for 4.4.5.